### PR TITLE
Search for jar file inside BASEDIR

### DIFF
--- a/robozonky-app/src/main/assembly/filtered-resources/robozonky.sh
+++ b/robozonky-app/src/main/assembly/filtered-resources/robozonky.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+BASEDIR=$(dirname "$0")
 ROBOZONKY_PORT=${ROBOZONKY_PORT:-7091}
 ROBOZONKY_IP=${ROBOZONKY_IP:-localhost}
 JMX_OPTS="-Djava.rmi.server.hostname=$ROBOZONKY_IP -Dcom.sun.management.jmxremote.port=$ROBOZONKY_PORT -Dcom.sun.management.jmxremote.rmi.port=$ROBOZONKY_PORT -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 ROBOZONKY_OPTS="$JMX_OPTS $JAVA_OPTS -Dlogback.configurationFile=logback.xml -Dfile.encoding=UTF-8 -Djava.net.preferIPv4Stack=true"
-$JAVA_HOME/bin/java $ROBOZONKY_OPTS -jar bin/robozonky-app-${project.version}.jar "$@"
+$JAVA_HOME/bin/java $ROBOZONKY_OPTS -jar ${BASEDIR}/bin/robozonky-app-${project.version}.jar "$@"


### PR DESCRIPTION
Abych mohl mit configuracni soubory, logy, ... mimo stazene robozonky, tak to mam takto:

robozonky@hypnos:/home/robozonky# pwd
/home/robozonky
robozonky@hypnos:/home/robozonky# ls -1
logback.xml
logs
robozonky
robozonky.keystore
robozonky-notifications.cfg
robozonky-onovy.cfg
robozonky.state
start.sh
robozonky@hypnos:/home/robozonky# ls robozonky
bin  examples  extensions  LICENSE  robozonky.bat  robozonky.sh
robozonky@hypnos:/home/robozonky# cat start.sh
#!/bin/bash

cd /home/robozonky
robozonky/robozonky.sh -g robozonky.keystore -p #pwd# -r -x zonkoid:#id# daemon -s robozonky-onovy.cfg

Od verze 3.0 mi to prestalo fungovat, protoze robozonky.sh hleda jar v aktualnim adresari. Tento PR to opravuje do puvodni verze.