### PR TITLE
Allow sorting on certain Zonky queries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,3 +16,5 @@ build_script:
   - mvn post-integration-test -DskipTests --batch-mode
 test_script:
   - mvn test --batch-mode
+cache:
+  - C:\Users\appveyor\.m2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,6 @@ install:
 build_script:
   - mvn post-integration-test -DskipTests --batch-mode
 test_script:
-  - mvn test --batch-mode
+  - mvn post-integration-test --batch-mode
 cache:
   - C:\Users\appveyor\.m2

--- a/robozonky-api/src/main/java/com/github/triceo/robozonky/api/marketplaces/Marketplace.java
+++ b/robozonky-api/src/main/java/com/github/triceo/robozonky/api/marketplaces/Marketplace.java
@@ -59,4 +59,9 @@ public interface Marketplace extends AutoCloseable, Runnable {
     @Override
     void run();
 
+    @Override
+    default void close() throws Exception {
+        // don't force implementations to override
+    }
+
 }

--- a/robozonky-api/src/main/java/com/github/triceo/robozonky/api/remote/enums/MainIncomeType.java
+++ b/robozonky-api/src/main/java/com/github/triceo/robozonky/api/remote/enums/MainIncomeType.java
@@ -34,7 +34,8 @@ public enum MainIncomeType {
     STUDENT, // "student"
     UNEMPLOYED, // "bez zaměstnání"
     LIBERAL_PROFESSION, // "svobodné povolání"
-    OTHERS_MAIN; // "ostatní"
+    OTHERS_MAIN, // "ostatní"
+    NEXT_WORK; // there is one loan in the API with this value; the value is not documented and has no translation
 
     static class MainIncomeTypeDeserializer extends JsonDeserializer<MainIncomeType> {
 

--- a/robozonky-app/src/main/java/com/github/triceo/robozonky/app/investing/AbstractInvestmentMode.java
+++ b/robozonky-app/src/main/java/com/github/triceo/robozonky/app/investing/AbstractInvestmentMode.java
@@ -69,12 +69,7 @@ abstract class AbstractInvestmentMode implements InvestmentMode {
 
     @Override
     public Optional<Collection<Investment>> get() {
-        try (final ApiProvider api = new ApiProvider()) {
-            LOGGER.trace("Executing.");
-            return this.execute(api);
-        } finally {
-            LOGGER.trace("Finished.");
-        }
+        return this.execute(new ApiProvider());
     }
 
     protected boolean wasSuddenDeath() {

--- a/robozonky-app/src/test/java/com/github/triceo/robozonky/app/AppTest.java
+++ b/robozonky-app/src/test/java/com/github/triceo/robozonky/app/AppTest.java
@@ -30,10 +30,10 @@ import com.github.triceo.robozonky.api.strategies.InvestmentStrategy;
 import com.github.triceo.robozonky.app.authentication.AuthenticationHandler;
 import com.github.triceo.robozonky.app.investing.DirectInvestmentMode;
 import com.github.triceo.robozonky.app.investing.InvestmentMode;
-import com.github.triceo.robozonky.app.investing.SingleShotInvestmentMode;
 import com.github.triceo.robozonky.app.investing.Investor;
-import com.github.triceo.robozonky.common.remote.Api;
+import com.github.triceo.robozonky.app.investing.SingleShotInvestmentMode;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
+import com.github.triceo.robozonky.common.remote.OAuth;
 import com.github.triceo.robozonky.common.remote.Zonky;
 import com.github.triceo.robozonky.common.secrets.SecretProvider;
 import org.assertj.core.api.Assertions;
@@ -69,7 +69,7 @@ public class AppTest extends AbstractEventsAndStateLeveragingTest {
         final AuthenticationHandler auth = Mockito.mock(AuthenticationHandler.class);
         Mockito.doThrow(IllegalStateException.class).when(auth).execute(ArgumentMatchers.any(), ArgumentMatchers.any());
         final ApiProvider api = Mockito.mock(ApiProvider.class);
-        Mockito.when(api.oauth()).thenReturn(Mockito.mock(Api.class));
+        Mockito.when(api.oauth()).thenReturn(Mockito.mock(OAuth.class));
         final Loan loan = Mockito.mock(Loan.class);
         Mockito.when(loan.getDatePublished()).thenReturn(OffsetDateTime.now());
         // and now test
@@ -86,7 +86,7 @@ public class AppTest extends AbstractEventsAndStateLeveragingTest {
         final AuthenticationHandler auth = Mockito.mock(AuthenticationHandler.class);
         Mockito.when(auth.execute(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Collections.emptyList());
         final ApiProvider api = Mockito.mock(ApiProvider.class);
-        Mockito.when(api.oauth()).thenReturn(Mockito.mock(Api.class));
+        Mockito.when(api.oauth()).thenReturn(Mockito.mock(OAuth.class));
         final Loan loan = Mockito.mock(Loan.class);
         Mockito.when(loan.getDatePublished()).thenReturn(OffsetDateTime.now());
         Mockito.when(api.authenticated(ArgumentMatchers.any())).thenReturn(Mockito.mock(Zonky.class));

--- a/robozonky-app/src/test/java/com/github/triceo/robozonky/app/authentication/AuthenticationHandlerTest.java
+++ b/robozonky-app/src/test/java/com/github/triceo/robozonky/app/authentication/AuthenticationHandlerTest.java
@@ -33,6 +33,7 @@ import com.github.triceo.robozonky.api.remote.ZonkyOAuthApi;
 import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
 import com.github.triceo.robozonky.common.remote.Api;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
+import com.github.triceo.robozonky.common.remote.OAuth;
 import com.github.triceo.robozonky.common.remote.Zonky;
 import com.github.triceo.robozonky.common.secrets.KeyStoreHandler;
 import com.github.triceo.robozonky.common.secrets.SecretProvider;
@@ -124,9 +125,8 @@ public class AuthenticationHandlerTest {
     public void simpleTokenBasedWithExistingTokenNoop() throws JAXBException {
         final SecretProvider secretProvider = AuthenticationHandlerTest.mockExistingProvider(OffsetDateTime.now());
         final AuthenticationHandler h = AuthenticationHandler.tokenBased(secretProvider, Duration.ofSeconds(60));
-        final ZonkyOAuthApi zonkyOauth = Mockito.mock(ZonkyOAuthApi.class);
         final ApiProvider apiProvider = Mockito.mock(ApiProvider.class);
-        Mockito.when(apiProvider.oauth()).thenReturn(new Api<>(zonkyOauth));
+        Mockito.when(apiProvider.oauth()).thenReturn(Mockito.mock(OAuth.class));
         Assertions.assertThat(h.execute(apiProvider, null)).isEmpty();
     }
 

--- a/robozonky-app/src/test/java/com/github/triceo/robozonky/app/authentication/AuthenticationHandlerTest.java
+++ b/robozonky-app/src/test/java/com/github/triceo/robozonky/app/authentication/AuthenticationHandlerTest.java
@@ -28,10 +28,7 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.xml.bind.JAXBException;
 
-import com.github.triceo.robozonky.api.remote.ControlApi;
-import com.github.triceo.robozonky.api.remote.ZonkyOAuthApi;
 import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
-import com.github.triceo.robozonky.common.remote.Api;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
 import com.github.triceo.robozonky.common.remote.OAuth;
 import com.github.triceo.robozonky.common.remote.Zonky;
@@ -72,21 +69,18 @@ public class AuthenticationHandlerTest {
         final SecretProvider secrets = AuthenticationHandlerTest.getNewProvider();
         final AuthenticationHandler auth = AuthenticationHandler.passwordBased(secrets);
         Assertions.assertThat(auth.getSecretProvider()).isSameAs(secrets);
-        final ZonkyOAuthApi zonkyOauth = Mockito.mock(ZonkyOAuthApi.class);
+        final OAuth zonkyOauth = Mockito.mock(OAuth.class);
         Mockito.doReturn(AuthenticatorTest.TOKEN).when(zonkyOauth)
-                .login(ArgumentMatchers.anyString(), ArgumentMatchers.anyString(), ArgumentMatchers.anyString(),
-                        ArgumentMatchers.anyString());
+                .login(ArgumentMatchers.anyString(), ArgumentMatchers.any());
         final ApiProvider apiProvider = Mockito.spy(new ApiProvider());
         final Zonky z = Mockito.mock(Zonky.class);
-        Mockito.doReturn(new Api<>(zonkyOauth)).when(apiProvider).oauth();
+        Mockito.doReturn(zonkyOauth).when(apiProvider).oauth();
         Mockito.doReturn(z).when(apiProvider).authenticated(Mockito.eq(AuthenticatorTest.TOKEN));
         Assertions.assertThat(auth.execute(apiProvider, (a) -> Collections.emptyList())).isEmpty();
         Mockito.verify(zonkyOauth, Mockito.times(1))
                 .login(ArgumentMatchers.eq(secrets.getUsername()),
-                        ArgumentMatchers.eq(new String(secrets.getPassword())), ArgumentMatchers.any(),
-                        ArgumentMatchers.any());
-        Mockito.verify(zonkyOauth, Mockito.never())
-                .refresh(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+                        ArgumentMatchers.eq(secrets.getPassword()));
+        Mockito.verify(zonkyOauth, Mockito.never()).refresh(ArgumentMatchers.any());
         Mockito.verify(z, Mockito.times(1)).logout();
     }
 
@@ -94,10 +88,9 @@ public class AuthenticationHandlerTest {
     public void simplePasswordBasedNoop() throws IOException, KeyStoreException {
         final SecretProvider secrets = AuthenticationHandlerTest.getNewProvider();
         final AuthenticationHandler auth = AuthenticationHandler.passwordBased(secrets);
-        final ZonkyOAuthApi zonkyOauth = Mockito.mock(ZonkyOAuthApi.class);
         final ApiProvider apiProvider = Mockito.spy(new ApiProvider());
         final Zonky z = Mockito.mock(Zonky.class);
-        Mockito.doReturn(new Api<>(zonkyOauth)).when(apiProvider).oauth();
+        Mockito.doReturn(Mockito.mock(OAuth.class)).when(apiProvider).oauth();
         Mockito.doReturn(z).when(apiProvider).authenticated(Mockito.eq(AuthenticatorTest.TOKEN));
         Assertions.assertThat(auth.getSecretProvider()).isSameAs(secrets);
         Assertions.assertThat(auth.execute(apiProvider, null)).isEmpty();
@@ -107,17 +100,14 @@ public class AuthenticationHandlerTest {
     public void simpleTokenBasedWithExistingToken() throws JAXBException {
         final SecretProvider secretProvider = AuthenticationHandlerTest.mockExistingProvider(OffsetDateTime.now());
         final AuthenticationHandler auth = AuthenticationHandler.tokenBased(secretProvider, Duration.ofSeconds(60));
-        final ZonkyOAuthApi zonkyOauth = Mockito.mock(ZonkyOAuthApi.class);
+        final OAuth zonkyOauth = Mockito.mock(OAuth.class);
         final ApiProvider apiProvider = Mockito.spy(new ApiProvider());
         final Zonky z = Mockito.mock(Zonky.class);
-        Mockito.doReturn(new Api<>(zonkyOauth)).when(apiProvider).oauth();
+        Mockito.doReturn(zonkyOauth).when(apiProvider).oauth();
         Mockito.doReturn(z).when(apiProvider).authenticated(Mockito.eq(AuthenticatorTest.TOKEN));
         Assertions.assertThat(auth.execute(apiProvider, (a) -> Collections.emptyList())).isEmpty();
-        Mockito.verify(zonkyOauth, Mockito.never())
-                .refresh(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
-        Mockito.verify(zonkyOauth, Mockito.never())
-                .login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.anyString(),
-                        ArgumentMatchers.anyString());
+        Mockito.verify(zonkyOauth, Mockito.never()).refresh(ArgumentMatchers.any());
+        Mockito.verify(zonkyOauth, Mockito.never()).login(ArgumentMatchers.any(), ArgumentMatchers.any());
         Mockito.verify(z, Mockito.never()).logout();
     }
 
@@ -132,23 +122,19 @@ public class AuthenticationHandlerTest {
 
     @Test
     public void simpleTokenBasedWithoutToken() throws JAXBException, IOException, KeyStoreException {
-        final ZonkyOAuthApi zonkyOauth = Mockito.mock(ZonkyOAuthApi.class);
+        final OAuth zonkyOauth = Mockito.mock(OAuth.class);
         Mockito.doReturn(AuthenticatorTest.TOKEN).when(zonkyOauth)
-                .login(ArgumentMatchers.anyString(), ArgumentMatchers.anyString(), ArgumentMatchers.anyString(),
-                        ArgumentMatchers.anyString());
+                .login(ArgumentMatchers.anyString(), ArgumentMatchers.any());
         final ApiProvider apiProvider = Mockito.spy(new ApiProvider());
         final Zonky z = Mockito.mock(Zonky.class);
-        Mockito.doReturn(new Api<>(zonkyOauth)).when(apiProvider).oauth();
+        Mockito.doReturn(zonkyOauth).when(apiProvider).oauth();
         Mockito.doReturn(z).when(apiProvider).authenticated(Mockito.eq(AuthenticatorTest.TOKEN));
         final SecretProvider secrets = AuthenticationHandlerTest.getNewProvider();
         final AuthenticationHandler auth = AuthenticationHandler.tokenBased(secrets, Duration.ofSeconds(60));
         Assertions.assertThat(auth.execute(apiProvider, (a) -> Collections.emptyList())).isEmpty();
-        Mockito.verify(zonkyOauth, Mockito.never())
-                .refresh(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+        Mockito.verify(zonkyOauth, Mockito.never()).refresh(ArgumentMatchers.any());
         Mockito.verify(zonkyOauth, Mockito.times(1))
-                .login(ArgumentMatchers.eq(secrets.getUsername()),
-                        ArgumentMatchers.eq(new String(secrets.getPassword())), ArgumentMatchers.any(),
-                        ArgumentMatchers.any());
+                .login(ArgumentMatchers.eq(secrets.getUsername()), ArgumentMatchers.eq(secrets.getPassword()));
         Mockito.verify(z, Mockito.never()).logout();
     }
 
@@ -157,19 +143,17 @@ public class AuthenticationHandlerTest {
         final OffsetDateTime expired = OffsetDateTime.now().minus(300, ChronoUnit.SECONDS);
         final SecretProvider secrets = AuthenticationHandlerTest.mockExistingProvider(expired);
         final AuthenticationHandler auth = AuthenticationHandler.tokenBased(secrets, Duration.ofSeconds(60));
-        final ZonkyOAuthApi zonkyOauth = Mockito.mock(ZonkyOAuthApi.class);
+        final OAuth zonkyOauth = Mockito.mock(OAuth.class);
         final ZonkyApiToken token = new ZonkyApiToken(UUID.randomUUID().toString(), UUID.randomUUID().toString(), 299);
-        Mockito.when(zonkyOauth.login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.any())).thenReturn(token);
+        Mockito.when(zonkyOauth.login(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(token);
         final ApiProvider apiProvider = Mockito.spy(new ApiProvider());
         final Zonky z = Mockito.mock(Zonky.class);
-        Mockito.doReturn(new Api<>(zonkyOauth)).when(apiProvider).oauth();
+        Mockito.doReturn(zonkyOauth).when(apiProvider).oauth();
         Mockito.doReturn(z).when(apiProvider).authenticated(Mockito.eq(AuthenticatorTest.TOKEN));
         Assertions.assertThat(auth.execute(apiProvider, (a) -> Collections.emptyList())).isEmpty();
-        Mockito.verify(zonkyOauth, Mockito.never())
-                .refresh(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+        Mockito.verify(zonkyOauth, Mockito.never()).refresh(ArgumentMatchers.any());
         Mockito.verify(zonkyOauth, Mockito.times(1))
-                .login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+                .login(ArgumentMatchers.any(), ArgumentMatchers.any());
         Mockito.verify(z, Mockito.never()).logout();
     }
 
@@ -178,19 +162,16 @@ public class AuthenticationHandlerTest {
         final OffsetDateTime expiring = OffsetDateTime.now().minus(250, ChronoUnit.SECONDS);
         final SecretProvider secrets = AuthenticationHandlerTest.mockExistingProvider(expiring);
         final AuthenticationHandler auth = AuthenticationHandler.tokenBased(secrets, Duration.ofSeconds(60));
-        final ZonkyOAuthApi zonkyOauth = Mockito.mock(ZonkyOAuthApi.class);
+        final OAuth zonkyOauth = Mockito.mock(OAuth.class);
         final ZonkyApiToken token = new ZonkyApiToken(UUID.randomUUID().toString(), UUID.randomUUID().toString(), 299);
-        Mockito.when(zonkyOauth.refresh(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
-                .thenReturn(token);
+        Mockito.when(zonkyOauth.refresh(ArgumentMatchers.any())).thenReturn(token);
         final ApiProvider apiProvider = Mockito.spy(new ApiProvider());
         final Zonky z = Mockito.mock(Zonky.class);
-        Mockito.doReturn(new Api<>(zonkyOauth)).when(apiProvider).oauth();
+        Mockito.doReturn(zonkyOauth).when(apiProvider).oauth();
         Mockito.doReturn(z).when(apiProvider).authenticated(Mockito.eq(AuthenticatorTest.TOKEN));
         Assertions.assertThat(auth.execute(apiProvider, (a) -> Collections.emptyList())).isEmpty();
-        Mockito.verify(zonkyOauth, Mockito.times(1))
-                .refresh(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
-        Mockito.verify(zonkyOauth, Mockito.never())
-                .login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+        Mockito.verify(zonkyOauth, Mockito.times(1)).refresh(ArgumentMatchers.any());
+        Mockito.verify(zonkyOauth, Mockito.never()).login(ArgumentMatchers.any(), ArgumentMatchers.any());
         Mockito.verify(z, Mockito.never()).logout();
     }
 
@@ -199,20 +180,17 @@ public class AuthenticationHandlerTest {
         final OffsetDateTime expiring = OffsetDateTime.now().minus(298, ChronoUnit.SECONDS);
         final SecretProvider secrets = AuthenticationHandlerTest.mockExistingProvider(expiring);
         final AuthenticationHandler auth = AuthenticationHandler.tokenBased(secrets, Duration.ofSeconds(60));
-        final ControlApi zonky = Mockito.mock(ControlApi.class);
-        final ZonkyOAuthApi zonkyOauth = Mockito.mock(ZonkyOAuthApi.class);
+        final OAuth zonkyOauth = Mockito.mock(OAuth.class);
         final ZonkyApiToken token = new ZonkyApiToken(UUID.randomUUID().toString(), UUID.randomUUID().toString(), 299);
-        Mockito.when(zonkyOauth.login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.any())).thenReturn(token);
+        Mockito.when(zonkyOauth.login(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(token);
         final ApiProvider apiProvider = Mockito.spy(new ApiProvider());
         final Zonky z = Mockito.mock(Zonky.class);
-        Mockito.doReturn(new Api<>(zonkyOauth)).when(apiProvider).oauth();
+        Mockito.doReturn(zonkyOauth).when(apiProvider).oauth();
         Mockito.doReturn(z).when(apiProvider).authenticated(Mockito.eq(AuthenticatorTest.TOKEN));
         Assertions.assertThat(auth.execute(apiProvider, (a) -> Collections.emptyList())).isEmpty();
-        Mockito.verify(zonkyOauth, Mockito.never())
-                .refresh(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+        Mockito.verify(zonkyOauth, Mockito.never()).refresh(ArgumentMatchers.any());
         Mockito.verify(zonkyOauth, Mockito.times(1))
-                .login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
+                .login(ArgumentMatchers.any(), ArgumentMatchers.any());
         Mockito.verify(z, Mockito.never()).logout();
     }
 

--- a/robozonky-app/src/test/java/com/github/triceo/robozonky/app/authentication/AuthenticatorTest.java
+++ b/robozonky-app/src/test/java/com/github/triceo/robozonky/app/authentication/AuthenticatorTest.java
@@ -20,113 +20,57 @@ import java.time.Duration;
 import java.util.UUID;
 import java.util.function.Function;
 
-import com.github.triceo.robozonky.api.remote.ControlApi;
-import com.github.triceo.robozonky.api.remote.ZonkyOAuthApi;
 import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
 import com.github.triceo.robozonky.common.remote.OAuth;
 import org.assertj.core.api.Assertions;
-import org.jboss.resteasy.client.jaxrs.ResteasyClient;
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
-import org.mockito.internal.stubbing.defaultanswers.ReturnsEmptyValues;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 public class AuthenticatorTest {
 
-    private static final String DUMMY_URL = "http://localhost";
     private static final String DUMMY_USER = "a";
     private static final String DUMMY_PWD = "b";
-
-    private static class AnswerWithSelf implements Answer<Object> {
-        private final Answer<Object> delegate = new ReturnsEmptyValues();
-        private final Class<?> clazz;
-
-        public AnswerWithSelf(final Class<?> clazz) {
-            this.clazz = clazz;
-        }
-
-        public Object answer(final InvocationOnMock invocation) throws Throwable {
-            final Class<?> returnType = invocation.getMethod().getReturnType();
-            if (returnType == clazz) {
-                return invocation.getMock();
-            } else {
-                return delegate.answer(invocation);
-            }
-        }
-    }
 
     static final ZonkyApiToken TOKEN =
             new ZonkyApiToken(UUID.randomUUID().toString(), UUID.randomUUID().toString(), 299);
 
-    private static ResteasyClientBuilder mockResteasy() {
-        final ZonkyOAuthApi mock = Mockito.mock(ZonkyOAuthApi.class);
-        Mockito.when(mock.login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.any())).thenReturn(AuthenticatorTest.TOKEN);
-        Mockito.when(mock.refresh(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
-                .thenReturn(new ZonkyApiToken(String.valueOf(AuthenticatorTest.TOKEN.getRefreshToken()), UUID
-                        .randomUUID().toString(), 300));
-        final ResteasyWebTarget target = Mockito.mock(ResteasyWebTarget.class);
-        Mockito.when(target.proxy(ZonkyOAuthApi.class)).thenReturn(mock);
-        Mockito.when(target.proxy(ControlApi.class)).thenReturn(Mockito.mock(ControlApi.class));
-        final ResteasyClient client =
-                Mockito.mock(ResteasyClient.class, new AuthenticatorTest.AnswerWithSelf(ResteasyClient.class));
-        Mockito.when(client.target(ArgumentMatchers.anyString())).thenReturn(target);
-        final ResteasyClientBuilder builder = Mockito.mock(ResteasyClientBuilder.class);
-        Mockito.when(builder.build()).thenReturn(client);
-        return builder;
-    }
-
     @Test
     public void credentialBasedAuthentication() {
-        final ResteasyClientBuilder mock = AuthenticatorTest.mockResteasy();
-        final ZonkyOAuthApi apiMock = mock.build().target(AuthenticatorTest.DUMMY_URL).proxy(ZonkyOAuthApi.class);
         final ApiProvider provider = Mockito.mock(ApiProvider.class);
-        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
+        final OAuth oauth = Mockito.mock(OAuth.class);
+        Mockito.when(provider.oauth()).thenReturn(oauth);
         final Function<ApiProvider, ZonkyApiToken> a = Authenticator.withCredentials(AuthenticatorTest.DUMMY_USER,
                 AuthenticatorTest.DUMMY_PWD.toCharArray());
-        final ZonkyApiToken auth = a.apply(provider);
-        Assertions.assertThat(auth).isNotNull();
-        Mockito.verify(apiMock, Mockito.times(1))
+        a.apply(provider);
+        Mockito.verify(oauth, Mockito.times(1))
                 .login(ArgumentMatchers.eq(AuthenticatorTest.DUMMY_USER),
-                        ArgumentMatchers.eq(AuthenticatorTest.DUMMY_PWD), ArgumentMatchers.any(),
-                        ArgumentMatchers.any());
+                        ArgumentMatchers.eq(AuthenticatorTest.DUMMY_PWD.toCharArray()));
     }
 
     @Test
     public void tokenBasedAuthentication() {
-        final ResteasyClientBuilder mock = AuthenticatorTest.mockResteasy();
-        final ZonkyOAuthApi apiMock = mock.build().target(AuthenticatorTest.DUMMY_URL).proxy(ZonkyOAuthApi.class);
         final ApiProvider provider = Mockito.mock(ApiProvider.class);
-        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
+        final OAuth oauth = Mockito.mock(OAuth.class);
+        Mockito.when(provider.oauth()).thenReturn(oauth);
         final Function<ApiProvider, ZonkyApiToken> a =
                 Authenticator.withAccessToken(AuthenticatorTest.DUMMY_USER, AuthenticatorTest.TOKEN, Duration.ZERO);
         final ZonkyApiToken auth = a.apply(provider);
         Assertions.assertThat(auth).isEqualTo(AuthenticatorTest.TOKEN);
-        Mockito.verify(apiMock, Mockito.never()).login(ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.any(), ArgumentMatchers.any());
-        Mockito.verify(apiMock, Mockito.never()).refresh(ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.any());
+        Mockito.verify(oauth, Mockito.never()).login(ArgumentMatchers.any(), ArgumentMatchers.any());
+        Mockito.verify(oauth, Mockito.never()).refresh(ArgumentMatchers.any());
     }
 
     @Test
     public void tokenBasedAuthenticationWithRefresh() {
-        final ResteasyClientBuilder mock = AuthenticatorTest.mockResteasy();
-        final ZonkyOAuthApi apiMock = mock.build().target(AuthenticatorTest.DUMMY_URL).proxy(ZonkyOAuthApi.class);
         final ApiProvider provider = Mockito.mock(ApiProvider.class);
-        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
-        final ZonkyApiToken result =
-                Authenticator.withAccessToken(AuthenticatorTest.DUMMY_USER, AuthenticatorTest.TOKEN,
-                        Duration.ofSeconds(AuthenticatorTest.TOKEN.getExpiresIn())).apply(provider);
-        Mockito.verify(apiMock, Mockito.never()).login(ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.any(), ArgumentMatchers.any());
-        Mockito.verify(apiMock, Mockito.times(1)).refresh(ArgumentMatchers.any(),
-                ArgumentMatchers.any(), ArgumentMatchers.any());
-        Assertions.assertThat(result).isNotNull().isNotEqualTo(AuthenticatorTest.TOKEN);
+        final OAuth oauth = Mockito.mock(OAuth.class);
+        Mockito.when(provider.oauth()).thenReturn(oauth);
+        Authenticator.withAccessToken(AuthenticatorTest.DUMMY_USER, AuthenticatorTest.TOKEN,
+                Duration.ofSeconds(AuthenticatorTest.TOKEN.getExpiresIn())).apply(provider);
+        Mockito.verify(oauth, Mockito.never()).login(ArgumentMatchers.any(), ArgumentMatchers.any());
+        Mockito.verify(oauth, Mockito.times(1)).refresh(ArgumentMatchers.any());
     }
 
 }

--- a/robozonky-app/src/test/java/com/github/triceo/robozonky/app/authentication/AuthenticatorTest.java
+++ b/robozonky-app/src/test/java/com/github/triceo/robozonky/app/authentication/AuthenticatorTest.java
@@ -23,8 +23,8 @@ import java.util.function.Function;
 import com.github.triceo.robozonky.api.remote.ControlApi;
 import com.github.triceo.robozonky.api.remote.ZonkyOAuthApi;
 import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
-import com.github.triceo.robozonky.common.remote.Api;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
+import com.github.triceo.robozonky.common.remote.OAuth;
 import org.assertj.core.api.Assertions;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
@@ -86,7 +86,7 @@ public class AuthenticatorTest {
         final ResteasyClientBuilder mock = AuthenticatorTest.mockResteasy();
         final ZonkyOAuthApi apiMock = mock.build().target(AuthenticatorTest.DUMMY_URL).proxy(ZonkyOAuthApi.class);
         final ApiProvider provider = Mockito.mock(ApiProvider.class);
-        Mockito.when(provider.oauth()).thenReturn(new Api<>(apiMock));
+        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
         final Function<ApiProvider, ZonkyApiToken> a = Authenticator.withCredentials(AuthenticatorTest.DUMMY_USER,
                 AuthenticatorTest.DUMMY_PWD.toCharArray());
         final ZonkyApiToken auth = a.apply(provider);
@@ -102,7 +102,7 @@ public class AuthenticatorTest {
         final ResteasyClientBuilder mock = AuthenticatorTest.mockResteasy();
         final ZonkyOAuthApi apiMock = mock.build().target(AuthenticatorTest.DUMMY_URL).proxy(ZonkyOAuthApi.class);
         final ApiProvider provider = Mockito.mock(ApiProvider.class);
-        Mockito.when(provider.oauth()).thenReturn(new Api<>(apiMock));
+        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
         final Function<ApiProvider, ZonkyApiToken> a =
                 Authenticator.withAccessToken(AuthenticatorTest.DUMMY_USER, AuthenticatorTest.TOKEN, Duration.ZERO);
         final ZonkyApiToken auth = a.apply(provider);
@@ -118,7 +118,7 @@ public class AuthenticatorTest {
         final ResteasyClientBuilder mock = AuthenticatorTest.mockResteasy();
         final ZonkyOAuthApi apiMock = mock.build().target(AuthenticatorTest.DUMMY_URL).proxy(ZonkyOAuthApi.class);
         final ApiProvider provider = Mockito.mock(ApiProvider.class);
-        Mockito.when(provider.oauth()).thenReturn(new Api<>(apiMock));
+        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
         final ZonkyApiToken result =
                 Authenticator.withAccessToken(AuthenticatorTest.DUMMY_USER, AuthenticatorTest.TOKEN,
                         Duration.ofSeconds(AuthenticatorTest.TOKEN.getExpiresIn())).apply(provider);

--- a/robozonky-app/src/test/java/com/github/triceo/robozonky/app/investing/AbstractInvestingTest.java
+++ b/robozonky-app/src/test/java/com/github/triceo/robozonky/app/investing/AbstractInvestingTest.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.temporal.TemporalAmount;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Random;
@@ -28,15 +29,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.github.triceo.robozonky.api.notifications.Event;
-import com.github.triceo.robozonky.api.remote.LoanApi;
-import com.github.triceo.robozonky.api.remote.ZonkyOAuthApi;
 import com.github.triceo.robozonky.api.remote.entities.Loan;
 import com.github.triceo.robozonky.api.remote.entities.Wallet;
 import com.github.triceo.robozonky.api.strategies.LoanDescriptor;
 import com.github.triceo.robozonky.app.AbstractEventsAndStateLeveragingTest;
 import com.github.triceo.robozonky.app.Events;
-import com.github.triceo.robozonky.common.remote.Api;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
+import com.github.triceo.robozonky.common.remote.OAuth;
 import com.github.triceo.robozonky.common.remote.Zonky;
 import org.junit.Before;
 import org.mockito.ArgumentMatchers;
@@ -85,8 +84,8 @@ public class AbstractInvestingTest extends AbstractEventsAndStateLeveragingTest 
 
     protected static ApiProvider harmlessApi(final Zonky zonky) {
         final ApiProvider p = Mockito.spy(new ApiProvider());
-        Mockito.doReturn(new Api<>(Mockito.mock(ZonkyOAuthApi.class))).when(p).oauth();
-        Mockito.doReturn(new Api<>(Mockito.mock(LoanApi.class))).when(p).marketplace();
+        Mockito.doReturn(Mockito.mock(OAuth.class)).when(p).oauth();
+        Mockito.doReturn(Collections.emptyList()).when(p).marketplace();
         Mockito.doReturn(zonky).when(p).authenticated(ArgumentMatchers.any());
         return p;
     }

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/extensions/Checker.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/extensions/Checker.java
@@ -43,7 +43,8 @@ public class Checker {
             Comparator.comparing(Loan::getInterestRate).thenComparing(Checker.SUBCOMPARATOR);
 
     static Optional<Loan> getOneLoanFromMarketplace(final Supplier<ApiProvider> apiProviderSupplier) {
-        try (final ApiProvider p = apiProviderSupplier.get()) {
+        try {
+            final ApiProvider p = apiProviderSupplier.get();
             final Collection<Loan> loans = p.marketplace();
             /*
              * find a loan that is likely to stay on the marketplace for so long that the notification will

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/extensions/Checker.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/extensions/Checker.java
@@ -29,9 +29,7 @@ import com.github.triceo.robozonky.api.confirmations.ConfirmationProvider;
 import com.github.triceo.robozonky.api.confirmations.RequestId;
 import com.github.triceo.robozonky.api.notifications.EventListener;
 import com.github.triceo.robozonky.api.notifications.RoboZonkyTestingEvent;
-import com.github.triceo.robozonky.api.remote.LoanApi;
 import com.github.triceo.robozonky.api.remote.entities.Loan;
-import com.github.triceo.robozonky.common.remote.Api;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,11 +44,12 @@ public class Checker {
 
     static Optional<Loan> getOneLoanFromMarketplace(final Supplier<ApiProvider> apiProviderSupplier) {
         try (final ApiProvider p = apiProviderSupplier.get()) {
-            final Api<LoanApi> oauth = p.marketplace();
-            final Collection<Loan> loans = oauth.execute(LoanApi::items);
+            final Collection<Loan> loans = p.marketplace();
             /*
              * find a loan that is likely to stay on the marketplace for so long that the notification will
              * successfully come through.
+             *
+             * // FIXME what happens in installer when there is no loans?
              */
             return loans.stream().sorted(Checker.COMPARATOR).findFirst();
         } catch (final Exception t) {

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/Api.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/Api.java
@@ -27,7 +27,7 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClient;
  *
  * @param <T> Type of the API to be handled.
  */
-public class Api<T> implements ApiBlueprint<T>, AutoCloseable {
+class Api<T> implements ApiBlueprint<T>, AutoCloseable {
 
     private final AtomicReference<ResteasyClient> client;
     private final T api;

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/ApiProvider.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/ApiProvider.java
@@ -100,14 +100,22 @@ public class ApiProvider implements AutoCloseable {
         return new OAuth(this.obtain(ZonkyOAuthApi.class, ApiProvider.ZONKY_URL, new AuthenticationFilter()));
     }
 
+    protected <T> Collection<T> marketplace(final Class<? extends EntityCollectionApi<T>> target, final String url) {
+        try (final Api<? extends EntityCollectionApi<T>> api = this.obtain(target, url, new RoboZonkyFilter())) {
+            return api.execute(a -> {
+                return a.items();
+            });
+        }
+    }
+
     /**
-     * Retrieve user-specific Zonky API which does not require authentication.
+     * Retrieve available loans from Zonky marketplace cache, which requires no authentication.
      *
-     * @return New API instance.
+     * @return Loans existing in the marketplace at the time this method was called.
      * @throws IllegalStateException If {@link #close()} already called.
      */
-    public Api<LoanApi> marketplace() {
-        return this.obtain(LoanApi.class, ApiProvider.ZONKY_URL, new RoboZonkyFilter());
+    public Collection<Loan> marketplace() {
+        return this.marketplace(LoanApi.class, ApiProvider.ZONKY_URL);
     }
 
     public Zonky authenticated(final ZonkyApiToken token) {

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/ApiProvider.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/ApiProvider.java
@@ -96,8 +96,8 @@ public class ApiProvider implements AutoCloseable {
      * @return New API instance.
      * @throws IllegalStateException If {@link #close()} already called.
      */
-    public Api<ZonkyOAuthApi> oauth() {
-        return this.obtain(ZonkyOAuthApi.class, ApiProvider.ZONKY_URL, new AuthenticationFilter());
+    public OAuth oauth() {
+        return new OAuth(this.obtain(ZonkyOAuthApi.class, ApiProvider.ZONKY_URL, new AuthenticationFilter()));
     }
 
     /**

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/Field.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/Field.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Lukáš Petrovický
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.triceo.robozonky.common.remote;
+
+public interface Field<S> {
+
+    String id();
+
+}

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/InvestmentField.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/InvestmentField.java
@@ -16,22 +16,17 @@
 
 package com.github.triceo.robozonky.common.remote;
 
-import com.github.triceo.robozonky.api.remote.entities.Loan;
+import com.github.triceo.robozonky.api.remote.entities.Investment;
 
-public enum LoanField implements Field<Loan> {
+public enum InvestmentField implements Field<Investment> {
 
-    COVERED("covered"),
-    DATE_PUBLISHED("datePublished"),
-    INTEREST_RATE("interestRate"),
-    PURPOSE("purpose"),
-    RATING("rating"),
-    REMAINING_INVESTMENT("remainingInvestment"),
-    TERM_IN_MONTHS("termInMonths"),
-    TOPPED("topped");
+    ID("id"),
+    TIME_CREATED("timeCreated"),
+    LOAN_STATUS("loan.status");
 
     private final String id;
 
-    LoanField(final String id) {
+    InvestmentField(final String id) {
         this.id = id;
     }
 

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/LoanField.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/LoanField.java
@@ -16,21 +16,35 @@
 
 package com.github.triceo.robozonky.common.remote;
 
-import com.github.triceo.robozonky.api.remote.LoanApi;
 import com.github.triceo.robozonky.api.remote.entities.Loan;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
 
-// FIXME will fail when Zonky API is down
-public class PaginatedApiTest {
+public enum LoanField implements Field<Loan> {
 
-    @Test
-    public void redirectAndLiveQuery() {
-        final RoboZonkyFilter f = new RoboZonkyFilter();
-        final PaginatedApi<Loan, LoanApi> pa = new PaginatedApi<>(LoanApi.class, "http://api.zonky.cz", null);
-        final PaginatedResult<Loan> loans = pa.execute(LoanApi::items, Sort.unspecified(), 0, 10, f);
-        Assertions.assertThat(loans.getCurrentPageId()).isEqualTo(0);
-        Assertions.assertThat(loans.getTotalResultCount()).isGreaterThanOrEqualTo(0);
+    ID("id"),
+    TERM_IN_MONTHS("termInMonths"),
+    INVESTMENTS_COUNT("investmentsCount"),
+    QUESTIONS_COUNT("questionsCount"),
+    USER_ID ("userId"), AMOUNT("amount"),
+    REMAINING_INVESTMENT("remainingInvestment"),
+    NAME("name"),
+    NICK_NAME("nickName"),
+    INTEREST_RATE("interestRate"),
+    DATE_PUBLISHED("datePublished"),
+    DEADLINE("deadline"),
+    RATING("rating"),
+    INVESTMENT_RATE("investmentRate"),
+    MAIN_INCOME_TYPE("mainIncomeType"),
+    REGION("region"),
+    PURPOSE("purpose");
+
+    private final String id;
+
+    LoanField(final String id) {
+        this.id = id;
+    }
+
+    public String id() {
+        return this.id;
     }
 
 }

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/OAuth.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/OAuth.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Lukáš Petrovický
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.triceo.robozonky.common.remote;
+
+import java.util.Arrays;
+
+import com.github.triceo.robozonky.api.remote.ZonkyOAuthApi;
+import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
+
+public class OAuth implements AutoCloseable {
+
+    private final Api<ZonkyOAuthApi> api;
+
+    OAuth(final Api<ZonkyOAuthApi> api) {
+        this.api = api;
+    }
+
+    public ZonkyApiToken login(final String username, final char[] password) {
+        return api.execute(a -> {
+            return a.login(username, Arrays.toString(password), "password", "SCOPE_APP_WEB");
+        });
+    }
+
+    public ZonkyApiToken refresh(final ZonkyApiToken token) {
+        return api.execute(a -> {
+            return a.refresh(Arrays.toString(token.getRefreshToken()), token.getType(), token.getScope());
+        });
+    }
+
+    @Override
+    public void close() {
+        this.api.close();
+    }
+}

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/OAuth.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/OAuth.java
@@ -16,8 +16,6 @@
 
 package com.github.triceo.robozonky.common.remote;
 
-import java.util.Arrays;
-
 import com.github.triceo.robozonky.api.remote.ZonkyOAuthApi;
 import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
 
@@ -31,13 +29,13 @@ public class OAuth implements AutoCloseable {
 
     public ZonkyApiToken login(final String username, final char[] password) {
         return api.execute(a -> {
-            return a.login(username, Arrays.toString(password), "password", "SCOPE_APP_WEB");
+            return a.login(username, String.valueOf(password), "password", "SCOPE_APP_WEB");
         });
     }
 
     public ZonkyApiToken refresh(final ZonkyApiToken token) {
         return api.execute(a -> {
-            return a.refresh(Arrays.toString(token.getRefreshToken()), token.getType(), token.getScope());
+            return a.refresh(String.valueOf(token.getRefreshToken()), token.getType(), token.getScope());
         });
     }
 

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/PaginatedApi.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/PaginatedApi.java
@@ -23,7 +23,7 @@ import com.github.triceo.robozonky.api.remote.EntityCollectionApi;
 import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 
-public class PaginatedApi<S, T extends EntityCollectionApi<S>> implements ApiBlueprint<T> {
+class PaginatedApi<S, T extends EntityCollectionApi<S>> implements ApiBlueprint<T> {
 
     private final ZonkyApiToken token;
     private final Class<T> api;

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/PaginatedApi.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/PaginatedApi.java
@@ -38,10 +38,11 @@ public class PaginatedApi<S, T extends EntityCollectionApi<S>> implements ApiBlu
     @Override
     public <Q> Q execute(final Function<T, Q> function) {
         final AuthenticatedFilter filter = new AuthenticatedFilter(this.token);
-        return this.execute(function, filter);
+        return this.execute(function, Sort.unspecified(), filter);
     }
 
-    <Q> Q execute(final Function<T, Q> function, final RoboZonkyFilter filter) {
+    <Q> Q execute(final Function<T, Q> function, final Sort<S> sort, final RoboZonkyFilter filter) {
+        sort.apply(filter);
         final ResteasyClient client = ProxyFactory.newResteasyClient(filter);
         try {
             final T proxy = ProxyFactory.newProxy(client, api, url);
@@ -51,15 +52,16 @@ public class PaginatedApi<S, T extends EntityCollectionApi<S>> implements ApiBlu
         }
     }
 
-    public PaginatedResult<S> execute(final Function<T, Collection<S>> function, final int pageNo, final int pageSize) {
-        return this.execute(function, pageNo, pageSize, new AuthenticatedFilter(this.token));
+    public PaginatedResult<S> execute(final Function<T, Collection<S>> function, final Sort<S> sort,
+                                      final int pageNo, final int pageSize) {
+        return this.execute(function, sort, pageNo, pageSize, new AuthenticatedFilter(this.token));
     }
 
-    PaginatedResult<S> execute(final Function<T, Collection<S>> function, final int pageNo, final int pageSize,
-                               final RoboZonkyFilter filter) {
+    PaginatedResult<S> execute(final Function<T, Collection<S>> function, final Sort<S> sort,
+                               final int pageNo, final int pageSize, final RoboZonkyFilter filter) {
         filter.setRequestHeader("X-Page", String.valueOf(pageNo));
         filter.setRequestHeader("X-Size", String.valueOf(pageSize));
-        final Collection<S> result = this.execute(function, filter);
+        final Collection<S> result = this.execute(function, sort, filter);
         final int totalSize = filter.getLastResponseHeader("X-Total")
                 .map(Integer::parseInt)
                 .orElse(-1);

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/PaginatedImpl.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/PaginatedImpl.java
@@ -26,13 +26,16 @@ final class PaginatedImpl<T> implements Paginated<T> {
 
     private final PaginatedApi<T, ? extends EntityCollectionApi<T>> api;
     private final int pageSize;
+    private final Sort<T> ordering;
     private PaginatedResult<T> itemsOnPage;
 
     PaginatedImpl(final PaginatedApi<T, ? extends EntityCollectionApi<T>> api) {
-        this(api, Settings.INSTANCE.getDefaultApiPageSize()); // for testing purposes
+        this(api, Sort.unspecified(), Settings.INSTANCE.getDefaultApiPageSize()); // for testing purposes
     }
 
-    public PaginatedImpl(final PaginatedApi<T, ? extends EntityCollectionApi<T>> api, final int pageSize) {
+    public PaginatedImpl(final PaginatedApi<T, ? extends EntityCollectionApi<T>> api, final Sort<T> ordering,
+                         final int pageSize) {
+        this.ordering = ordering;
         this.api = api;
         this.pageSize = pageSize;
         this.nextPage();
@@ -40,7 +43,7 @@ final class PaginatedImpl<T> implements Paginated<T> {
 
     @Override
     public boolean nextPage() {
-        this.itemsOnPage = api.execute(EntityCollectionApi::items, this.getPageId() + 1, this.pageSize);
+        this.itemsOnPage = api.execute(EntityCollectionApi::items, this.ordering,this.getPageId() + 1, this.pageSize);
         return this.itemsOnPage != null && !this.itemsOnPage.getPage().isEmpty();
     }
 

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/Sort.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/Sort.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Lukáš Petrovický
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.triceo.robozonky.common.remote;
+
+public interface Sort<S> {
+
+    static <S> Sort<S> unspecified() {
+        return new Sort<S>() {
+
+            @Override
+            public Sort<S> thenBy(final Field<S> field, final boolean ascending) {
+                throw new IllegalStateException("Cannot sort with unspecified.");
+            }
+
+            @Override
+            public void apply(final RoboZonkyFilter filter) {
+                // do not apply any ordering
+            }
+        };
+    }
+
+    static <S> Sort<S> by(final Field<S> field) {
+        return Sort.by(field, true);
+    }
+
+    static <S> Sort<S> by(final Field<S> field, final boolean ascending) {
+        return new SortImpl<>(field, ascending);
+    }
+
+    default Sort<S> thenBy(final Field<S> field) {
+        return this.thenBy(field, true);
+    }
+
+    Sort<S> thenBy(Field<S> field, boolean ascending);
+
+    void apply(RoboZonkyFilter filter);
+
+}

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/SortImpl.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/SortImpl.java
@@ -20,7 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class SortImpl<S> implements Sort<S> {
+class SortImpl<S> implements Sort<S> {
 
     private final Map<Field<S>, Boolean> ordering = new LinkedHashMap<>(1);
 

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/SortImpl.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/SortImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Lukáš Petrovický
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.triceo.robozonky.common.remote;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SortImpl<S> implements Sort<S> {
+
+    private final Map<Field<S>, Boolean> ordering = new LinkedHashMap<>(1);
+
+    SortImpl(final Field<S> first, final boolean ascending) {
+        this.ordering.put(first, ascending);
+    }
+
+    private synchronized String getOrdering() {
+        return ordering.entrySet().stream()
+                .map(e -> {
+                    final String field = e.getKey().id();
+                    return e.getValue() ? field : "-" + field;
+                }).collect(Collectors.joining(","));
+    }
+
+    @Override
+    public synchronized SortImpl<S> thenBy(final Field<S> field, final boolean ascending) {
+        if (ordering.containsKey(field)) {
+            throw new IllegalArgumentException("Field already used: " + field);
+        }
+        this.ordering.put(field, ascending);
+        return this;
+    }
+
+    @Override
+    public void apply(final RoboZonkyFilter filter) {
+        final String ordering = this.getOrdering();
+        if (ordering.length() > 0) {
+            filter.setRequestHeader("X-Order", ordering);
+        }
+    }
+
+}

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/Zonky.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/Zonky.java
@@ -92,16 +92,6 @@ public class Zonky implements AutoCloseable {
         return Zonky.getStream(walletApi);
     }
 
-    /**
-     * Retrieve blocked amounts from user's wallet via {@link WalletApi}, in a given order.
-     *
-     * @param ordering Ordering in which the results should be returned.
-     * @return All items from the remote API, lazy-loaded.
-     */
-    public Stream<BlockedAmount> getBlockedAmounts(final Sort<BlockedAmount> ordering) {
-        return Zonky.getStream(walletApi, ordering);
-    }
-
     public Statistics getStatistics() {
         return portfolioApi.execute(PortfolioApi::statistics);
     }

--- a/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/Zonky.java
+++ b/robozonky-common/src/main/java/com/github/triceo/robozonky/common/remote/Zonky.java
@@ -66,12 +66,19 @@ public class Zonky implements AutoCloseable {
     }
 
     private static <T, S extends EntityCollectionApi<T>> Stream<T> getStream(final PaginatedApi<T, S> api) {
-        return Zonky.getStream(api, Settings.INSTANCE.getDefaultApiPageSize());
+        return Zonky.getStream(api, Sort.unspecified());
     }
 
     private static <T, S extends EntityCollectionApi<T>> Stream<T> getStream(final PaginatedApi<T, S> api,
-                                                                             final int pageSize) {
-        final Paginated<T> p = new PaginatedImpl<>(api, pageSize);
+                                                                             final Sort<T> ordering) {
+        return Zonky.getStream(api, Settings.INSTANCE.getDefaultApiPageSize(), ordering);
+    }
+
+
+    private static <T, S extends EntityCollectionApi<T>> Stream<T> getStream(final PaginatedApi<T, S> api,
+                                                                             final int pageSize,
+                                                                             final Sort<T> ordering) {
+        final Paginated<T> p = new PaginatedImpl<>(api, ordering, pageSize);
         final Spliterator<T> s = new EntitySpliterator<>(p);
         return StreamSupport.stream(s, false);
     }
@@ -83,6 +90,16 @@ public class Zonky implements AutoCloseable {
      */
     public Stream<BlockedAmount> getBlockedAmounts() {
         return Zonky.getStream(walletApi);
+    }
+
+    /**
+     * Retrieve blocked amounts from user's wallet via {@link WalletApi}, in a given order.
+     *
+     * @param ordering Ordering in which the results should be returned.
+     * @return All items from the remote API, lazy-loaded.
+     */
+    public Stream<BlockedAmount> getBlockedAmounts(final Sort<BlockedAmount> ordering) {
+        return Zonky.getStream(walletApi, ordering);
     }
 
     public Statistics getStatistics() {
@@ -99,6 +116,22 @@ public class Zonky implements AutoCloseable {
     }
 
     /**
+     * Retrieve investments from user's portfolio via {@link PortfolioApi}, in a given order.
+     *
+     * @param ordering Ordering in which the results should be returned.
+     * @return All items from the remote API, lazy-loaded. Does not include investments represented by blocked amounts.
+     */
+    public Stream<Investment> getInvestments(final Sort<Investment> ordering) {
+        return Zonky.getStream(portfolioApi, ordering);
+    }
+
+    public Loan getLoan(final int id) {
+        return loanApi.execute(api -> {
+            return api.item(id);
+        });
+    }
+
+    /**
      * Retrieve loans from marketplace via {@link LoanApi}.
      *
      * @return All items from the remote API, lazy-loaded.
@@ -107,10 +140,14 @@ public class Zonky implements AutoCloseable {
         return Zonky.getStream(loanApi);
     }
 
-    public Loan getLoan(final int id) {
-        return loanApi.execute(api -> {
-            return api.item(id);
-        });
+    /**
+     * Retrieve loans from marketplace via {@link LoanApi}, in a given order.
+     *
+     * @param ordering Ordering in which the results should be returned.
+     * @return All items from the remote API, lazy-loaded.
+     */
+    public Stream<Loan> getAvailableLoans(final Sort<Loan> ordering) {
+        return Zonky.getStream(loanApi, ordering);
     }
 
     public void logout() {

--- a/robozonky-common/src/test/java/com/github/triceo/robozonky/common/extensions/CheckerTest.java
+++ b/robozonky-common/src/test/java/com/github/triceo/robozonky/common/extensions/CheckerTest.java
@@ -25,9 +25,7 @@ import com.github.triceo.robozonky.api.confirmations.ConfirmationProvider;
 import com.github.triceo.robozonky.api.confirmations.ConfirmationType;
 import com.github.triceo.robozonky.api.notifications.EventListener;
 import com.github.triceo.robozonky.api.notifications.RoboZonkyTestingEvent;
-import com.github.triceo.robozonky.api.remote.LoanApi;
 import com.github.triceo.robozonky.api.remote.entities.Loan;
-import com.github.triceo.robozonky.common.remote.Api;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -47,10 +45,8 @@ public class CheckerTest {
 
     @Test
     public void confirmationsMarketplaceWithoutLoans() {
-        final LoanApi api = Mockito.mock(LoanApi.class);
-        Mockito.when(api.items()).thenReturn(Collections.emptyList());
         final ApiProvider provider = Mockito.mock(ApiProvider.class);
-        Mockito.when(provider.marketplace()).thenReturn(new Api<>(api));
+        Mockito.when(provider.marketplace()).thenReturn(Collections.emptyList());
         final Optional<Boolean> result =
                 Checker.confirmations(Mockito.mock(ConfirmationProvider.class), "", new char[0], () -> provider);
         Assertions.assertThat(result).isPresent().hasValue(false);
@@ -58,10 +54,8 @@ public class CheckerTest {
 
     private static ApiProvider mockApiThatReturnsOneLoan() {
         final Loan l = Mockito.mock(Loan.class);
-        final LoanApi api = Mockito.mock(LoanApi.class);
-        Mockito.doReturn(Collections.singletonList(l)).when(api).items();
         final ApiProvider provider = Mockito.mock(ApiProvider.class);
-        Mockito.doReturn(new Api<>(api)).when(provider).marketplace();
+        Mockito.doReturn(Collections.singletonList(l)).when(provider).marketplace();
         return provider;
     }
 

--- a/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/ApiProviderTest.java
+++ b/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/ApiProviderTest.java
@@ -25,20 +25,18 @@ public class ApiProviderTest {
 
     @Test
     public void unathenticatedApis() {
-        try (final ApiProvider provider = new ApiProvider()) {
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(provider.marketplace()).isNotNull();
-                Assertions.assertThat(provider.oauth()).isNotNull();
-            });
-        }
+        final ApiProvider provider = new ApiProvider();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(provider.marketplace()).isNotNull();
+            Assertions.assertThat(provider.oauth()).isNotNull();
+        });
     }
 
     @Test
     public void athenticatedApis() {
         final ZonkyApiToken token = AuthenticatedFilterTest.TOKEN;
-        try (final ApiProvider provider = new ApiProvider()) {
-            Assertions.assertThat(provider.authenticated(token)).isNotNull();
-        }
+        final ApiProvider provider = new ApiProvider();
+        Assertions.assertThat(provider.authenticated(token)).isNotNull();
     }
 
 }

--- a/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/EntitySpliteratorTest.java
+++ b/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/EntitySpliteratorTest.java
@@ -65,11 +65,12 @@ public class EntitySpliteratorTest {
         final Loan loan2 = new Loan(2, 300);
         final Loan loan3 = new Loan(3, 400);
         final PaginatedApi<Loan, LoanApi> api = Mockito.mock(PaginatedApi.class);
-        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(0), ArgumentMatchers.eq(pageSize)))
+        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.eq(0),
+                ArgumentMatchers.eq(pageSize)))
                 .thenReturn(EntitySpliteratorTest.getResult(Arrays.asList(loan1, loan2), 0, totalResultCount));
-        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(1), ArgumentMatchers.eq(pageSize)))
+        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.eq(1), ArgumentMatchers.eq(pageSize)))
                 .thenReturn(EntitySpliteratorTest.getResult(Collections.singleton(loan3), 1, totalResultCount));
-        final Paginated<Loan> p = new PaginatedImpl<>(api,2);
+        final Paginated<Loan> p = new PaginatedImpl<>(api, Sort.unspecified(),2);
         final EntitySpliterator<Loan> e = new EntitySpliterator<>(p);
         Assertions.assertThat(e.getExactSizeIfKnown()).isEqualTo(totalResultCount);
         final Stream<Loan> s = StreamSupport.stream(e, false);

--- a/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/FieldTest.java
+++ b/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/FieldTest.java
@@ -16,29 +16,28 @@
 
 package com.github.triceo.robozonky.common.remote;
 
-import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
 
-public class ApiProviderTest {
+public class FieldTest {
 
-    @Test
-    public void unathenticatedApis() {
-        try (final ApiProvider provider = new ApiProvider()) {
-            SoftAssertions.assertSoftly(softly -> {
-                softly.assertThat(provider.marketplace()).isNotNull();
-                Assertions.assertThat(provider.oauth()).isNotNull();
-            });
-        }
+    private <T> void unique(final Field<T>... values) {
+        final Set<String> uniqueValues = Stream.of(values).map(Field::id).collect(Collectors.toSet());
+        Assertions.assertThat(uniqueValues).hasSize(values.length);
     }
 
     @Test
-    public void athenticatedApis() {
-        final ZonkyApiToken token = AuthenticatedFilterTest.TOKEN;
-        try (final ApiProvider provider = new ApiProvider()) {
-            Assertions.assertThat(provider.authenticated(token)).isNotNull();
-        }
+    public void uniqueInvestmentFields() {
+        unique(InvestmentField.values());
+    }
+
+    @Test
+    public void uniqueLoanFields() {
+        unique(LoanField.values());
     }
 
 }

--- a/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/OAuthTest.java
+++ b/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/OAuthTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Lukáš Petrovický
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.triceo.robozonky.common.remote;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.github.triceo.robozonky.api.remote.ZonkyOAuthApi;
+import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+public class OAuthTest {
+
+    private static final String USERNAME = "username", PASSWORD = "password";
+
+    @Test
+    public void login() {
+        final ZonkyOAuthApi api = Mockito.mock(ZonkyOAuthApi.class);
+        final Api<ZonkyOAuthApi> wrapper = new Api<>(api);
+        try (final OAuth oauth = new OAuth(wrapper)) {
+            oauth.login(USERNAME, PASSWORD.toCharArray());
+        }
+        Mockito.verify(api, Mockito.times(1))
+                .login(ArgumentMatchers.eq(USERNAME), ArgumentMatchers.eq(PASSWORD),
+                        ArgumentMatchers.eq("password"),
+                        ArgumentMatchers.eq("SCOPE_APP_WEB"));
+        Assertions.assertThat(wrapper.isClosed()).isTrue();
+    }
+
+    @Test
+    public void refresh() {
+        final String originalTokenId = UUID.randomUUID().toString();
+        final ZonkyApiToken originToken = new ZonkyApiToken(UUID.randomUUID().toString(), originalTokenId,
+                OffsetDateTime.now());
+        final ZonkyApiToken resultToken = Mockito.mock(ZonkyApiToken.class);
+        final ZonkyOAuthApi api = Mockito.mock(ZonkyOAuthApi.class);
+        Mockito.when(api.refresh(ArgumentMatchers.eq(originalTokenId),
+                ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(resultToken);
+        final Api<ZonkyOAuthApi> wrapper = new Api<>(api);
+        try (final OAuth oauth = new OAuth(wrapper)) {
+            final ZonkyApiToken returnedToken = oauth.refresh(originToken);
+            Assertions.assertThat(returnedToken).isEqualTo(resultToken);
+        }
+        Assertions.assertThat(wrapper.isClosed()).isTrue();
+    }
+
+}

--- a/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/PaginatedImplTest.java
+++ b/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/PaginatedImplTest.java
@@ -34,7 +34,8 @@ public class PaginatedImplTest {
         final PaginatedApi<Loan, LoanApi> api = Mockito.mock(PaginatedApi.class);
         final int pageSize = Settings.INSTANCE.getDefaultApiPageSize();
         // when execute is called with the right parameters, we pretend the API returned no results
-        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(0), ArgumentMatchers.eq(pageSize)))
+        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.eq(0),
+                ArgumentMatchers.eq(pageSize)))
                 .thenReturn(new PaginatedResult<>(Collections.emptyList(), 0, 0));
         final Paginated<Loan> p = new PaginatedImpl<>(api);
         SoftAssertions.assertSoftly(softly -> {
@@ -51,12 +52,12 @@ public class PaginatedImplTest {
         final PaginatedApi<Loan, LoanApi> api = Mockito.mock(PaginatedApi.class);
         final int pageSize = 1;
         // when execute calls for first page, we pretend the API returned 1 result
-        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(0), ArgumentMatchers.eq(pageSize)))
+        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.eq(0), ArgumentMatchers.eq(pageSize)))
                 .thenReturn(new PaginatedResult<>(Collections.singleton(new Loan(1, 200)), 0, 1));
         // when execute calls for second page, we pretend the API returned no results
-        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.eq(1), ArgumentMatchers.eq(pageSize)))
+        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.eq(1), ArgumentMatchers.eq(pageSize)))
                 .thenReturn(new PaginatedResult<>(Collections.emptyList(), 1, 1));
-        final Paginated<Loan> p = new PaginatedImpl<>(api, pageSize);
+        final Paginated<Loan> p = new PaginatedImpl<>(api, Sort.unspecified(), pageSize);
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(p.getExpectedPageSize()).isEqualTo(pageSize);
             softly.assertThat(p.getPageId()).isEqualTo(0);

--- a/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/SortTest.java
+++ b/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/SortTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Lukáš Petrovický
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.triceo.robozonky.common.remote;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+public class SortTest {
+
+    @Test
+    public void unspecified() {
+        final RoboZonkyFilter filter = Mockito.mock(RoboZonkyFilter.class);
+        Sort.unspecified().apply(filter);
+        Mockito.verify(filter, Mockito.times(0))
+                .setRequestHeader(ArgumentMatchers.any(), ArgumentMatchers.any());
+    }
+
+    @Test
+    public void simple() {
+        final RoboZonkyFilter filter = Mockito.mock(RoboZonkyFilter.class);
+        Sort.by(LoanField.COVERED).apply(filter);
+        Mockito.verify(filter, Mockito.times(1))
+                .setRequestHeader(ArgumentMatchers.eq("X-Order"), ArgumentMatchers.eq("covered"));
+    }
+
+    @Test
+    public void simpleDescending() {
+        final RoboZonkyFilter filter = Mockito.mock(RoboZonkyFilter.class);
+        Sort.by(LoanField.COVERED, false).apply(filter);
+        Mockito.verify(filter, Mockito.times(1))
+                .setRequestHeader(ArgumentMatchers.eq("X-Order"), ArgumentMatchers.eq("-covered"));
+    }
+
+    @Test
+    public void complex() {
+        final RoboZonkyFilter filter = Mockito.mock(RoboZonkyFilter.class);
+        Sort.by(LoanField.COVERED).thenBy(LoanField.DATE_PUBLISHED).thenBy(LoanField.INTEREST_RATE, false)
+                .apply(filter);
+        Mockito.verify(filter, Mockito.times(1))
+                .setRequestHeader(ArgumentMatchers.eq("X-Order"),
+                        ArgumentMatchers.eq("covered,datePublished,-interestRate"));
+    }
+
+    @Test
+    public void orderTwiceOnSameField() {
+        Assertions.assertThatThrownBy(() -> Sort.by(LoanField.COVERED).thenBy(LoanField.COVERED))
+                .isInstanceOf(IllegalArgumentException.class);
+
+    }
+
+}

--- a/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/ZonkyTest.java
+++ b/robozonky-common/src/test/java/com/github/triceo/robozonky/common/remote/ZonkyTest.java
@@ -41,7 +41,8 @@ public class ZonkyTest {
     private <T, S extends EntityCollectionApi<T>> PaginatedApi<T, S> mockApi() {
         final PaginatedApi<T, S> api = Mockito.mock(PaginatedApi.class);
         final PaginatedResult<T> apiReturn = new PaginatedResult<>(Collections.emptyList(), 0, 0);
-        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt()))
+        Mockito.when(api.execute(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.anyInt(),
+                ArgumentMatchers.anyInt()))
                 .thenReturn(apiReturn);
         return api;
     }

--- a/robozonky-installer/robozonky-installer-panels/src/main/java/com/github/triceo/robozonky/installer/panels/ZonkySettingsValidator.java
+++ b/robozonky-installer/robozonky-installer-panels/src/main/java/com/github/triceo/robozonky/installer/panels/ZonkySettingsValidator.java
@@ -54,14 +54,13 @@ public class ZonkySettingsValidator implements DataValidator {
     public DataValidator.Status validateData(final InstallData installData) {
         final String username = Variables.ZONKY_USERNAME.getValue(installData);
         final String password = Variables.ZONKY_PASSWORD.getValue(installData);
-        try (final ApiProvider p = apiSupplier.get()) { // test login with the credentials
-            try (final OAuth oauth = p.oauth()) {
-                ZonkySettingsValidator.LOGGER.info("Logging in.");
-                final ZonkyApiToken token = oauth.login(username, password.toCharArray());
-                ZonkySettingsValidator.LOGGER.info("Logging out.");
-                try (final Zonky z = p.authenticated(token)) {
-                    z.logout();
-                }
+        final ApiProvider p = apiSupplier.get();
+        try (final OAuth oauth = p.oauth()) {
+            ZonkySettingsValidator.LOGGER.info("Logging in.");
+            final ZonkyApiToken token = oauth.login(username, password.toCharArray());
+            ZonkySettingsValidator.LOGGER.info("Logging out.");
+            try (final Zonky z = p.authenticated(token)) {
+                z.logout();
             }
             return DataValidator.Status.OK;
         } catch (final Exception t) {

--- a/robozonky-installer/robozonky-installer-panels/src/main/java/com/github/triceo/robozonky/installer/panels/ZonkySettingsValidator.java
+++ b/robozonky-installer/robozonky-installer-panels/src/main/java/com/github/triceo/robozonky/installer/panels/ZonkySettingsValidator.java
@@ -22,10 +22,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ws.rs.ServerErrorException;
 
-import com.github.triceo.robozonky.api.remote.ZonkyOAuthApi;
 import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
-import com.github.triceo.robozonky.common.remote.Api;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
+import com.github.triceo.robozonky.common.remote.OAuth;
 import com.github.triceo.robozonky.common.remote.Zonky;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.installer.DataValidator;
@@ -56,11 +55,9 @@ public class ZonkySettingsValidator implements DataValidator {
         final String username = Variables.ZONKY_USERNAME.getValue(installData);
         final String password = Variables.ZONKY_PASSWORD.getValue(installData);
         try (final ApiProvider p = apiSupplier.get()) { // test login with the credentials
-            try (final Api<ZonkyOAuthApi> oauth = p.oauth()) {
+            try (final OAuth oauth = p.oauth()) {
                 ZonkySettingsValidator.LOGGER.info("Logging in.");
-                final ZonkyApiToken token = oauth.execute(api -> {
-                    return api.login(username, password, "password", "SCOPE_APP_WEB");
-                });
+                final ZonkyApiToken token = oauth.login(username, password.toCharArray());
                 ZonkySettingsValidator.LOGGER.info("Logging out.");
                 try (final Zonky z = p.authenticated(token)) {
                     z.logout();

--- a/robozonky-installer/robozonky-installer-panels/src/test/java/com/github/triceo/robozonky/installer/panels/ZonkySettingsValidatorTest.java
+++ b/robozonky-installer/robozonky-installer-panels/src/test/java/com/github/triceo/robozonky/installer/panels/ZonkySettingsValidatorTest.java
@@ -22,8 +22,8 @@ import javax.ws.rs.core.Response;
 
 import com.github.triceo.robozonky.api.remote.ZonkyOAuthApi;
 import com.github.triceo.robozonky.api.remote.entities.ZonkyApiToken;
-import com.github.triceo.robozonky.common.remote.Api;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
+import com.github.triceo.robozonky.common.remote.OAuth;
 import com.github.triceo.robozonky.common.remote.Zonky;
 import com.izforge.izpack.api.data.InstallData;
 import com.izforge.izpack.api.installer.DataValidator;
@@ -63,7 +63,7 @@ public class ZonkySettingsValidatorTest {
         final ZonkyOAuthApi oauth = Mockito.mock(ZonkyOAuthApi.class);
         Mockito.when(oauth.login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
                 ArgumentMatchers.any())).thenReturn(token);
-        Mockito.when(provider.oauth()).thenReturn(new Api<>(oauth));
+        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
         final Zonky zonky = Mockito.mock(Zonky.class);
         Mockito.when(provider.authenticated(ArgumentMatchers.eq(token)))
                 .thenReturn(zonky);
@@ -87,7 +87,7 @@ public class ZonkySettingsValidatorTest {
         final ZonkyOAuthApi oauth = Mockito.mock(ZonkyOAuthApi.class);
         Mockito.when(oauth.login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
                 ArgumentMatchers.any())).thenThrow(new IllegalStateException());
-        Mockito.when(provider.oauth()).thenReturn(new Api<>(oauth));
+        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
         final InstallData d = ZonkySettingsValidatorTest.mockInstallData();
         // execute SUT
         final ZonkySettingsValidator validator = new ZonkySettingsValidator(() -> provider);
@@ -103,7 +103,7 @@ public class ZonkySettingsValidatorTest {
         final ZonkyOAuthApi oauth = Mockito.mock(ZonkyOAuthApi.class);
         Mockito.when(oauth.login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
                 ArgumentMatchers.any())).thenThrow(new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR));
-        Mockito.when(provider.oauth()).thenReturn(new Api<>(oauth));
+        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
         final InstallData d = ZonkySettingsValidatorTest.mockInstallData();
         // execute SUT
         final ZonkySettingsValidator validator = new ZonkySettingsValidator(() -> provider);

--- a/robozonky-installer/robozonky-installer-panels/src/test/java/com/github/triceo/robozonky/installer/panels/ZonkySettingsValidatorTest.java
+++ b/robozonky-installer/robozonky-installer-panels/src/test/java/com/github/triceo/robozonky/installer/panels/ZonkySettingsValidatorTest.java
@@ -60,10 +60,9 @@ public class ZonkySettingsValidatorTest {
         // mock data
         final ApiProvider provider = Mockito.mock(ApiProvider.class);
         final ZonkyApiToken token = Mockito.mock(ZonkyApiToken.class);
-        final ZonkyOAuthApi oauth = Mockito.mock(ZonkyOAuthApi.class);
-        Mockito.when(oauth.login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.any())).thenReturn(token);
-        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
+        final OAuth oauth = Mockito.mock(OAuth.class);
+        Mockito.when(oauth.login(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(token);
+        Mockito.when(provider.oauth()).thenReturn(oauth);
         final Zonky zonky = Mockito.mock(Zonky.class);
         Mockito.when(provider.authenticated(ArgumentMatchers.eq(token)))
                 .thenReturn(zonky);
@@ -75,8 +74,7 @@ public class ZonkySettingsValidatorTest {
         Assertions.assertThat(result).isEqualTo(DataValidator.Status.OK);
         Mockito.verify(oauth)
                 .login(ArgumentMatchers.eq(ZonkySettingsValidatorTest.USERNAME),
-                        ArgumentMatchers.eq(ZonkySettingsValidatorTest.PASSWORD), ArgumentMatchers.any(),
-                        ArgumentMatchers.any());
+                        ArgumentMatchers.eq(ZonkySettingsValidatorTest.PASSWORD.toCharArray()));
         Mockito.verify(zonky).logout();
     }
 
@@ -100,10 +98,10 @@ public class ZonkySettingsValidatorTest {
     public void error() {
         // mock data
         final ApiProvider provider = Mockito.mock(ApiProvider.class);
-        final ZonkyOAuthApi oauth = Mockito.mock(ZonkyOAuthApi.class);
-        Mockito.when(oauth.login(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
-                ArgumentMatchers.any())).thenThrow(new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR));
-        Mockito.when(provider.oauth()).thenReturn(Mockito.mock(OAuth.class));
+        final OAuth oauth = Mockito.mock(OAuth.class);
+        Mockito.when(oauth.login(ArgumentMatchers.any(), ArgumentMatchers.any()))
+                .thenThrow(new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR));
+        Mockito.when(provider.oauth()).thenReturn(oauth);
         final InstallData d = ZonkySettingsValidatorTest.mockInstallData();
         // execute SUT
         final ZonkySettingsValidator validator = new ZonkySettingsValidator(() -> provider);

--- a/robozonky-marketplaces/src/main/java/com/github/triceo/robozonky/marketplaces/AbstractMarketplace.java
+++ b/robozonky-marketplaces/src/main/java/com/github/triceo/robozonky/marketplaces/AbstractMarketplace.java
@@ -22,16 +22,15 @@ import java.util.function.Consumer;
 
 import com.github.triceo.robozonky.api.marketplaces.ExpectedTreatment;
 import com.github.triceo.robozonky.api.marketplaces.Marketplace;
-import com.github.triceo.robozonky.api.remote.EntityCollectionApi;
 import com.github.triceo.robozonky.api.remote.entities.Loan;
-import com.github.triceo.robozonky.common.remote.Api;
+import com.github.triceo.robozonky.common.remote.ApiProvider;
 
 abstract class AbstractMarketplace implements Marketplace {
 
     private final Collection<Consumer<Collection<Loan>>> loanListeners = new LinkedHashSet<>();
-    private final MarketplaceApiProvider apis = new MarketplaceApiProvider();
+    private final ApiProvider apis = this.api();
 
-    protected abstract Api<? extends EntityCollectionApi<Loan>> newApi(final MarketplaceApiProvider apis);
+    protected abstract ApiProvider api();
 
     @Override
     public synchronized boolean registerListener(final Consumer<Collection<Loan>> listener) {
@@ -45,12 +44,8 @@ abstract class AbstractMarketplace implements Marketplace {
 
     @Override
     public synchronized void run() {
-        try (final Api<? extends EntityCollectionApi<Loan>> wrapper = this.newApi(apis)) {
-            final Collection<Loan> loans = wrapper.execute(a -> {
-                return a.items();
-            });
-            loanListeners.forEach(l -> l.accept(loans));
-        }
+        final Collection<Loan> loans = apis.marketplace();
+        loanListeners.forEach(l -> l.accept(loans));
     }
 
     @Override

--- a/robozonky-marketplaces/src/main/java/com/github/triceo/robozonky/marketplaces/AbstractMarketplace.java
+++ b/robozonky-marketplaces/src/main/java/com/github/triceo/robozonky/marketplaces/AbstractMarketplace.java
@@ -48,8 +48,4 @@ abstract class AbstractMarketplace implements Marketplace {
         loanListeners.forEach(l -> l.accept(loans));
     }
 
-    @Override
-    public void close() {
-        apis.close();
-    }
 }

--- a/robozonky-marketplaces/src/main/java/com/github/triceo/robozonky/marketplaces/MarketplaceApiProvider.java
+++ b/robozonky-marketplaces/src/main/java/com/github/triceo/robozonky/marketplaces/MarketplaceApiProvider.java
@@ -16,14 +16,14 @@
 
 package com.github.triceo.robozonky.marketplaces;
 
-import com.github.triceo.robozonky.common.remote.Api;
+import java.util.Collection;
+
+import com.github.triceo.robozonky.api.remote.entities.Loan;
 import com.github.triceo.robozonky.common.remote.ApiProvider;
-import com.github.triceo.robozonky.common.remote.RoboZonkyFilter;
 
 class MarketplaceApiProvider extends ApiProvider {
 
     private static final String ZOTIFY_URL = "https://zotify.cz";
-    private static final RoboZonkyFilter FILTER = new RoboZonkyFilter();
 
     /**
      * Retrieve Zotify's marketplace cache.
@@ -31,8 +31,9 @@ class MarketplaceApiProvider extends ApiProvider {
      * @return New API instance.
      * @throws IllegalStateException If {@link #close()} already called.
      */
-    public Api<ZotifyApi> zotify() {
-        return this.obtain(ZotifyApi.class, MarketplaceApiProvider.ZOTIFY_URL, MarketplaceApiProvider.FILTER);
+    @Override
+    public Collection<Loan> marketplace() {
+        return this.marketplace(ZotifyApi.class, MarketplaceApiProvider.ZOTIFY_URL);
     }
 
 }

--- a/robozonky-marketplaces/src/main/java/com/github/triceo/robozonky/marketplaces/ZonkyMarketplace.java
+++ b/robozonky-marketplaces/src/main/java/com/github/triceo/robozonky/marketplaces/ZonkyMarketplace.java
@@ -16,14 +16,13 @@
 
 package com.github.triceo.robozonky.marketplaces;
 
-import com.github.triceo.robozonky.api.remote.LoanApi;
-import com.github.triceo.robozonky.common.remote.Api;
+import com.github.triceo.robozonky.common.remote.ApiProvider;
 
 class ZonkyMarketplace extends AbstractMarketplace {
 
     @Override
-    protected Api<LoanApi> newApi(final MarketplaceApiProvider apis) {
-        return apis.marketplace();
+    protected ApiProvider api() {
+        return new ApiProvider();
     }
 
 }

--- a/robozonky-marketplaces/src/main/java/com/github/triceo/robozonky/marketplaces/ZotifyMarketplace.java
+++ b/robozonky-marketplaces/src/main/java/com/github/triceo/robozonky/marketplaces/ZotifyMarketplace.java
@@ -16,15 +16,13 @@
 
 package com.github.triceo.robozonky.marketplaces;
 
-import com.github.triceo.robozonky.api.remote.EntityCollectionApi;
-import com.github.triceo.robozonky.api.remote.entities.Loan;
-import com.github.triceo.robozonky.common.remote.Api;
+import com.github.triceo.robozonky.common.remote.ApiProvider;
 
 class ZotifyMarketplace extends AbstractMarketplace {
 
     @Override
-    protected Api<? extends EntityCollectionApi<Loan>> newApi(final MarketplaceApiProvider apis) {
-        return apis.zotify();
+    protected ApiProvider api() {
+        return new MarketplaceApiProvider();
     }
 
 }

--- a/robozonky-marketplaces/src/test/java/com/github/triceo/robozonky/marketplaces/AbstractMarketplaceTest.java
+++ b/robozonky-marketplaces/src/test/java/com/github/triceo/robozonky/marketplaces/AbstractMarketplaceTest.java
@@ -24,7 +24,6 @@ import com.github.triceo.robozonky.api.marketplaces.ExpectedTreatment;
 import com.github.triceo.robozonky.api.marketplaces.Marketplace;
 import com.github.triceo.robozonky.api.remote.entities.Loan;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -39,7 +38,6 @@ public class AbstractMarketplaceTest {
         return Arrays.asList(new Object[] {ZotifyMarketplace.class}, new Object[] {ZonkyMarketplace.class});
     }
 
-    private static final MarketplaceApiProvider API_PROVIDER = new MarketplaceApiProvider();
     @Parameterized.Parameter
     public Class<? extends Marketplace> marketClass;
 
@@ -57,11 +55,5 @@ public class AbstractMarketplaceTest {
                     .accept(ArgumentMatchers.argThat(argument -> argument != null && !argument.isEmpty()));
         }
     }
-
-    @AfterClass
-    public static void close() {
-        AbstractMarketplaceTest.API_PROVIDER.close();
-    }
-
 
 }


### PR DESCRIPTION
At the same time, we refactor the `robozonky-common` APIs, making most of them package-private. As a result `ApiProvider` need no longer be `AutoCloseable`.